### PR TITLE
ohai less than 8 for 1.9.3

### DIFF
--- a/chef-encrypted-attributes.gemspec
+++ b/chef-encrypted-attributes.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'ffi-yajl', '~> 1.0'
   s.add_dependency 'chef', chef_version
   s.add_dependency 'mixlib-shellout', '< 1.6.1' if RUBY_VERSION < '1.9.3'
+  s.add_dependency 'ohai', '< 8' if RUBY_VERSION < '2'
 
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'chef-zero', '~> 3.2'

--- a/lib/chef/encrypted_attribute/version.rb
+++ b/lib/chef/encrypted_attribute/version.rb
@@ -20,6 +20,6 @@
 class Chef
   class EncryptedAttribute
     # `chef-encrypted-attributes` gem version.
-    VERSION = '0.5.0.dev'
+    VERSION = '0.5.1'
   end
 end


### PR DESCRIPTION
for whatever reasons, when i use the encrypted-attributes cookbook, it's bombing on chef_gem chef-encrypted-attributes... here's output when i attempt to manually install (i think/hope this is equivalent to chef gem install; please tell me if i'm wrong)

```
opower-qa-jenkins@qa-jenkins-slave-1020:~$ sudo /opt/chef/embedded/bin/gem install chef-encrypted-attributes
Fetching: ffi-yajl-1.4.0.gem (100%)
Building native extensions.  This could take a while...
Fetching: chef-encrypted-attributes-0.4.0.gem (100%)
Fetching: mime-types-2.4.3.gem (100%)
Fetching: systemu-2.6.5.gem (100%)
Fetching: mixlib-shellout-2.0.1.gem (100%)
Fetching: wmi-lite-1.0.0.gem (100%)
Fetching: ohai-8.2.0.gem (100%)
ERROR:  Error installing chef-encrypted-attributes:
	ohai requires Ruby version >= 2.0.0.
```

i think it's because im stuck using older chef (11.12) and ruby (1.9.3) so the version of ohai available is 7.0.2 and i can't install 8.

let me know if there's a better way around this.