### PR TITLE
Choose YAJL library based on chef version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Node attributes are encrypted using chef client and user keys with public key in
 
 * Ruby `>= 1.9`
 * Chef Client `~> 11.4`
-* ffi_yajl `~> 1.0` (included with Chef)
+* yajl_ruby `~> 1.1` or ffi_yajl `>= 1.0, <3.0` (included with Chef)
 * If you want to use protocol version 2 to use [GCM](http://en.wikipedia.org/wiki/Galois/Counter_Mode) (disabled by default):
  * Ruby `>= 2`.
  * OpenSSL `>= 1.0.1`.

--- a/chef-encrypted-attributes.gemspec
+++ b/chef-encrypted-attributes.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir.glob('{test,spec,features}/*')
   s.required_ruby_version = Gem::Requirement.new('>= 1.9.2')
 
-  s.add_dependency 'ffi-yajl', '>= 1.0', '< 3.0' # As Chef gem
   s.add_dependency 'chef', chef_version
 
   # Support old deprecated Ruby versions:

--- a/lib/chef/encrypted_attribute/encrypted_mash/version0.rb
+++ b/lib/chef/encrypted_attribute/encrypted_mash/version0.rb
@@ -20,17 +20,11 @@
 require 'chef/version'
 require 'chef/encrypted_attribute/encrypted_mash'
 require 'chef/encrypted_attribute/exceptions'
+require 'chef/encrypted_attribute/yajl'
 
 # Use the YAJL library that Chef provides.  Determine which to use based on
 # Chef version.
-major, minor = Chef::VERSION.split('.').take(2).map(&:to_i)
-if ([major, minor] <=> [11, 12]) == 1 # If [major, minor] > [11, 12]
-  require 'ffi_yajl'
-  YAJL_NAMESPACE = FFI_Yajl
-else
-  require 'yajl'
-  YAJL_NAMESPACE = Yajl
-end
+YAJL_NAMESPACE = Chef::EncryptedAttribute::Yajl.load_requirement(Chef::VERSION)
 
 class Chef
   class EncryptedAttribute

--- a/lib/chef/encrypted_attribute/yajl.rb
+++ b/lib/chef/encrypted_attribute/yajl.rb
@@ -1,0 +1,17 @@
+class Chef
+  class EncryptedAttribute
+    module Yajl
+      def self.load_requirement(chef_version)
+        if Gem::Requirement.new('< 11.13').satisfied_by?(
+          Gem::Version.new(chef_version)
+        )
+          require 'yajl'
+          ::Yajl
+        else
+          require 'ffi_yajl'
+          ::FFI_Yajl
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/knife/core/encrypted_attribute_editor_options.rb
+++ b/lib/chef/knife/core/encrypted_attribute_editor_options.rb
@@ -116,7 +116,7 @@ class Chef
         def edit_data_obj_to_string(data, format)
           case format
           when 'JSON', 'json'
-            FFI_Yajl::Parser.parse(data)
+            YAJL_NAMESPACE::Parser.parse(data)
           else
             data
           end

--- a/spec/unit/encrypted_attribute/encrypted_mash/version0.rb
+++ b/spec/unit/encrypted_attribute/encrypted_mash/version0.rb
@@ -230,7 +230,7 @@ describe Chef::EncryptedAttribute::EncryptedMash::Version0 do
       end]
       expect { body.decrypt(key1) }
         .to raise_error(
-          Chef::EncryptedAttribute::DecryptionFailure, /FFI_Yajl::ParseError/
+          Chef::EncryptedAttribute::DecryptionFailure, /ParseError/
         )
     end
   end # context #decrypt

--- a/spec/unit/encrypted_attribute/yajl_spec.rb
+++ b/spec/unit/encrypted_attribute/yajl_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'chef/encrypted_attribute/yajl'
+
+describe Chef::EncryptedAttribute::Yajl do
+  context '.load_requirement' do
+    [
+      { chef_version: '11.8.0',  library: 'yajl',     namespace: 'Yajl' },
+      { chef_version: '11.12.8', library: 'yajl',     namespace: 'Yajl' },
+      { chef_version: '11.14.0', library: 'ffi_yajl', namespace: 'FFI_Yajl' },
+      { chef_version: '12.3.0',  library: 'ffi_yajl', namespace: 'FFI_Yajl' },
+    ].each do |test|
+      it "given #{test[:chef_version].inspect}, requires "\
+          "#{test[:library].inspect} and returns #{test[:namespace]}" do
+        expect(described_class).to receive(:require).with(test[:library])
+        namespace = double('Constant')
+        stub_const(test[:namespace], namespace)
+        expect(described_class.load_requirement(test[:chef_version]))
+          .to eq namespace
+      end
+    end
+  end
+end

--- a/spec/unit/encrypted_attribute/yajl_spec.rb
+++ b/spec/unit/encrypted_attribute/yajl_spec.rb
@@ -7,7 +7,7 @@ describe Chef::EncryptedAttribute::Yajl do
       { chef_version: '11.8.0',  library: 'yajl',     namespace: 'Yajl' },
       { chef_version: '11.12.8', library: 'yajl',     namespace: 'Yajl' },
       { chef_version: '11.14.0', library: 'ffi_yajl', namespace: 'FFI_Yajl' },
-      { chef_version: '12.3.0',  library: 'ffi_yajl', namespace: 'FFI_Yajl' },
+      { chef_version: '12.3.0',  library: 'ffi_yajl', namespace: 'FFI_Yajl' }
     ].each do |test|
       it "given #{test[:chef_version].inspect}, requires "\
           "#{test[:library].inspect} and returns #{test[:namespace]}" do

--- a/spec/unit/knife/encrypted_attribute_create.rb
+++ b/spec/unit/knife/encrypted_attribute_create.rb
@@ -86,7 +86,7 @@ describe Chef::Knife::EncryptedAttributeCreate do
       expect(IO).to receive(:read).and_return('Bad-json')
       expect_any_instance_of(Chef::EncryptedAttribute)
         .not_to receive(:create_on_node)
-      expect { knife.run }.to raise_error(FFI_Yajl::ParseError)
+      expect { knife.run }.to raise_error(YAJL_NAMESPACE::ParseError)
     end
 
     it 'throws an error if the editor fails' do

--- a/spec/unit/knife/encrypted_attribute_edit.rb
+++ b/spec/unit/knife/encrypted_attribute_edit.rb
@@ -86,7 +86,7 @@ describe Chef::Knife::EncryptedAttributeEdit do
       expect(IO).to receive(:read).and_return('Bad-json')
       expect_any_instance_of(Chef::EncryptedAttribute)
         .not_to receive(:create_on_node)
-      expect { knife.run }.to raise_error(FFI_Yajl::ParseError)
+      expect { knife.run }.to raise_error(YAJL_NAMESPACE::ParseError)
     end
 
     it 'throws an error if the editor fails' do


### PR DESCRIPTION
The ffi-yajl dependency has caused me some trouble.
- It throws a warning when I load it and yajl-ruby in the same ruby process (which happens when requiring chef-encrypted-attributes) because they depend on incompatible underlying C libraries.
  - I believe I ran into a case where the conflicting C libraries actually caused a failure, although I haven't been able to reproduce it.
- Due to a bug in encrypted-attributes_cookbook's dependency installation (comparing versions as floating point numbers, so 11.12 < 11.8), it didn't get installed automatically when I needed it.

I propose removing the dependency and instead depending on whatever Chef provides.  An alternative would be to fix the cookbook, as I do in [this branch](https://github.com/ldanz/encrypted_attributes-cookbook/tree/dependency_version_fix) (and I can send a pull request for that if you prefer it over this solution).

A tradeoff here is between depending on ffi-yajl and yajl-ruby to have the same ruby interface (modulo the namespace) vs depending on their underlying C libraries to be compatible, neither of which is ideal.  But given that the cookbook is already ignoring dependencies when installing this gem, it seems more consistent not to have dependencies than to have them and then ignore them.  What do you think?

The ideal thing, IMO, would be to use Chef's JSON compatibility layer, JSONCompat, but that would take a larger refactor because chef-encrypted-attributes currently depends on quirks-mode in JSON parsing, which JSONCompat does not support.  This may be worth doing in the future, if you agree with it.